### PR TITLE
Fix saving comment date.

### DIFF
--- a/src/Products/Annotation/Annotator/BaseAnnotator.cs
+++ b/src/Products/Annotation/Annotator/BaseAnnotator.cs
@@ -99,7 +99,17 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
         {
             AnnotationReplyInfo reply = new AnnotationReplyInfo();
             reply.Message = comment.text;
-            DateTime date = DateTime.Parse(comment.time);
+            DateTime date;
+            try
+            {
+                long unixDate = long.Parse(comment.time);
+                DateTime start = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                date = start.AddMilliseconds(unixDate).ToLocalTime();
+            }
+            catch (System.Exception)
+            {
+                date = DateTime.Parse(comment.time);
+            }
             reply.RepliedOn = date;
             reply.UserName = comment.userName;
             return reply;


### PR DESCRIPTION
**Problem:**
Exception `String was not recognized as a valid DateTime` during save annotation with added comment.

**Solution:**
Was added code for handling for both possible formats of receiving comment dates: milliseconds from start Unix epoch and formatted date string.

**Screenshots:**
![image](https://user-images.githubusercontent.com/17431807/74348084-3288a980-4dc3-11ea-987b-4c9a0c67459b.png)