### PR TITLE
Fix SVG coordinates.

### DIFF
--- a/src/Products/Annotation/Annotator/AbstractBoxAnnotator.cs
+++ b/src/Products/Annotation/Annotator/AbstractBoxAnnotator.cs
@@ -35,8 +35,8 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
             string startPoint = svgPath.Replace("[a-zA-Z]+", "").Split(' ')[0];
             string endPoint = svgPath.Replace("[a-zA-Z]+", "").Split(' ')[1];
             string[] start = startPoint.Split(',');
-            float startX = float.Parse(start.Length > 0 ? start[0].Replace("M", "") : "0", CultureInfo.InvariantCulture);
-            float startY = float.Parse(start.Length > 0 ? start[1].Replace("M", "") : "0", CultureInfo.InvariantCulture);
+            float startX = float.Parse(start.Length > 0 ? start[0].Replace("M", "").Replace(",", ".") : "0", CultureInfo.InvariantCulture);
+            float startY = float.Parse(start.Length > 0 ? start[1].Replace("M", "").Replace(",", ".") : "0", CultureInfo.InvariantCulture);
             string[] end = endPoint.Split(',');
             float endX = float.Parse(end.Length > 0 ? end[0].Replace("L", "") : "0", CultureInfo.InvariantCulture) - startX;
             float endY = float.Parse(end.Length > 1 ? end[1].Replace("L", "") : "0", CultureInfo.InvariantCulture) - startY;

--- a/src/Products/Annotation/Annotator/AbstractBoxAnnotator.cs
+++ b/src/Products/Annotation/Annotator/AbstractBoxAnnotator.cs
@@ -21,8 +21,8 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
             StringBuilder builder = new StringBuilder().
                 Append("M").Append(box.X.ToString(CultureInfo.InvariantCulture)).
                 Append(",").Append(box.Y.ToString(CultureInfo.InvariantCulture)).
-                Append("L").Append(box.Width).
-                Append(",").Append(box.Height);
+                Append("L").Append(box.Width.ToString(CultureInfo.InvariantCulture)).
+                Append(",").Append(box.Height.ToString(CultureInfo.InvariantCulture));
             annotationInfo.SvgPath = builder.ToString();
             // set annotation position
             annotationInfo.AnnotationPosition = new Point(annotationData.left, annotationData.top);
@@ -38,8 +38,8 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
             float startX = float.Parse(start.Length > 0 ? start[0].Replace("M", "").Replace(",", ".") : "0", CultureInfo.InvariantCulture);
             float startY = float.Parse(start.Length > 0 ? start[1].Replace("M", "").Replace(",", ".") : "0", CultureInfo.InvariantCulture);
             string[] end = endPoint.Split(',');
-            float endX = float.Parse(end.Length > 0 ? end[0].Replace("L", "") : "0", CultureInfo.InvariantCulture) - startX;
-            float endY = float.Parse(end.Length > 1 ? end[1].Replace("L", "") : "0", CultureInfo.InvariantCulture) - startY;
+            float endX = float.Parse(end.Length > 0 ? end[0].Replace("L", "").Replace(",", ".") : "0", CultureInfo.InvariantCulture) - startX;
+            float endY = float.Parse(end.Length > 1 ? end[1].Replace("L", "").Replace(",", ".") : "0", CultureInfo.InvariantCulture) - startY;
             return new Rectangle(startX, startY, endX, endY);
         }
     }

--- a/src/Products/Annotation/Annotator/AbstractBoxAnnotator.cs
+++ b/src/Products/Annotation/Annotator/AbstractBoxAnnotator.cs
@@ -19,8 +19,8 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
             // set draw annotation properties
             Rectangle box = annotationInfo.Box;
             StringBuilder builder = new StringBuilder().
-                Append("M").Append(box.X).
-                Append(",").Append(box.Y).
+                Append("M").Append(box.X.ToString(CultureInfo.InvariantCulture)).
+                Append(",").Append(box.Y.ToString(CultureInfo.InvariantCulture)).
                 Append("L").Append(box.Width).
                 Append(",").Append(box.Height);
             annotationInfo.SvgPath = builder.ToString();


### PR DESCRIPTION
**Problem:**
Annotations that use SVG coordinates were placed wrong on the document because they have only commas in their SVG representation in `Russian` (and similar) locale.

**Solution:**
Were implemented changes for preserving dot as the decimal separator in the SVG coordinates.

**Tests:**
1. Create and save svg-related types of annotations in `Russian` locale.
2. Create and save svg-related types of annotations in `English` locale.

**Screenshots:**
![image](https://user-images.githubusercontent.com/17431807/74473955-95f30400-4eb5-11ea-9ba9-7a8cc44a56af.png)