### PR TITLE
Fix image document type check.

### DIFF
--- a/src/Products/Annotation/Controllers/AnnotationApiController.cs
+++ b/src/Products/Annotation/Controllers/AnnotationApiController.cs
@@ -413,7 +413,7 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Controllers
                 // get/set parameters
                 string documentGuid = annotateDocumentRequest.guid;
                 string password = annotateDocumentRequest.password;
-                string documentType = SupportedImageFormats.Contains(Path.GetExtension(annotateDocumentRequest.guid)) ? "image" : annotateDocumentRequest.documentType;
+                string documentType = SupportedImageFormats.Contains(Path.GetExtension(annotateDocumentRequest.guid).ToLowerInvariant()) ? "image" : annotateDocumentRequest.documentType;
                 string tempPath = GetTempPath(documentGuid);
 
                 AnnotationDataEntity[] annotationsData = annotateDocumentRequest.annotationsData;


### PR DESCRIPTION
Fix related to the issue described in following [comment](https://github.com/groupdocs-annotation/GroupDocs.Annotation-for-.NET-MVC/issues/67#issuecomment-827323541)