### PR TITLE
Fix annotations points coordinates calculating for images.

### DIFF
--- a/src/Products/Annotation/Annotator/AbstractTextAnnotator.cs
+++ b/src/Products/Annotation/Annotator/AbstractTextAnnotator.cs
@@ -21,5 +21,16 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
                     new Point(annotationData.left + annotationData.width, pageInfo.Height - annotationData.top - annotationData.height)
                 };
         }
+
+        protected static List<Point> GetPointsForImages(AnnotationDataEntity annotationData, PageInfo pageInfo)
+        {
+            return new List<Point>
+                {
+                    new Point(annotationData.left, annotationData.top + annotationData.height),
+                    new Point(annotationData.left + annotationData.width, annotationData.top + annotationData.height),
+                    new Point(annotationData.left, annotationData.top),
+                    new Point(annotationData.left + annotationData.width, annotationData.top)
+                };
+        }
     }
 }

--- a/src/Products/Annotation/Annotator/TextHighlightAnnotator.cs
+++ b/src/Products/Annotation/Annotator/TextHighlightAnnotator.cs
@@ -42,7 +42,9 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateImage()
         {
-            return AnnotateWord();
+            highlightAnnotation = InitAnnotationBase(highlightAnnotation) as HighlightAnnotation;
+            highlightAnnotation.Points = GetPointsForImages(annotationData, pageInfo);
+            return highlightAnnotation;
         }
 
         public override AnnotationBase AnnotateDiagram()

--- a/src/Products/Annotation/Annotator/TextRedactionAnnotator.cs
+++ b/src/Products/Annotation/Annotator/TextRedactionAnnotator.cs
@@ -31,7 +31,9 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateImage()
         {
-            throw new NotSupportedException(string.Format(Message, annotationData.type));
+            textRedactionAnnotation = InitAnnotationBase(textRedactionAnnotation) as TextRedactionAnnotation;
+            textRedactionAnnotation.Points = GetPointsForImages(annotationData, pageInfo);
+            return textRedactionAnnotation;
         }
 
         public override AnnotationBase AnnotateDiagram()

--- a/src/Products/Annotation/Annotator/TextStrikeoutAnnotator.cs
+++ b/src/Products/Annotation/Annotator/TextStrikeoutAnnotator.cs
@@ -44,7 +44,9 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateImage()
         {
-            return AnnotateWord();
+            strikeoutAnnotation = InitAnnotationBase(strikeoutAnnotation) as StrikeoutAnnotation;
+            strikeoutAnnotation.Points = GetPointsForImages(annotationData, pageInfo);
+            return strikeoutAnnotation;
         }
 
         public override AnnotationBase AnnotateDiagram()

--- a/src/Products/Annotation/Annotator/TextUnderlineAnnotator.cs
+++ b/src/Products/Annotation/Annotator/TextUnderlineAnnotator.cs
@@ -45,7 +45,10 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateImage()
         {
-            return AnnotateWord();
+            underlineAnnotation = InitAnnotationBase(underlineAnnotation) as UnderlineAnnotation;
+            underlineAnnotation.FontColor = 1201033;
+            underlineAnnotation.Points = GetPointsForImages(annotationData, pageInfo);
+            return underlineAnnotation;
         }
 
         public override AnnotationBase AnnotateDiagram()

--- a/src/Products/Annotation/Controllers/AnnotationApiController.cs
+++ b/src/Products/Annotation/Controllers/AnnotationApiController.cs
@@ -136,16 +136,7 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Controllers
                 IDocumentInfo info = annotator.Document.GetDocumentInfo();
                 AnnotationBase[] annotations = annotator.Get().ToArray();
                 description.guid = loadDocumentRequest.guid;
-
-                string documentType = string.Empty;
-                if (info.FileType != null)
-                {
-                    documentType = SupportedImageFormats.Contains(info.FileType.Extension) ? "image" : info.FileType.ToString();
-                }
-                else
-                {
-                    documentType = "Portable Document Format";
-                }
+                string documentType = getDocumentType(info);
 
                 description.supportedAnnotations = new SupportedAnnotations().GetSupportedAnnotations(documentType);
 
@@ -167,7 +158,7 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Controllers
 
                     if (annotations != null && annotations.Length > 0)
                     {
-                        page.SetAnnotations(AnnotationMapper.MapForPage(annotations, i+1, info.PagesInfo[i]));
+                        page.SetAnnotations(AnnotationMapper.MapForPage(annotations, i+1, info.PagesInfo[i], documentType));
                     }
 
                     if (pagesContent.Count > 0)
@@ -213,15 +204,16 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Controllers
 
                     IDocumentInfo info = annotator.Document.GetDocumentInfo();
                     AnnotationBase[] annotations = annotator.Get().ToArray();
+                    string documentType = getDocumentType(info);
 
                     if (annotations != null && annotations.Length > 0)
                     {
-                        loadedPage.SetAnnotations(AnnotationMapper.MapForPage(annotations, pageNumber, info.PagesInfo[pageNumber - 1]));
+                        loadedPage.SetAnnotations(AnnotationMapper.MapForPage(annotations, pageNumber, info.PagesInfo[pageNumber - 1], documentType));
                     }
 
                     string encodedImage = Convert.ToBase64String(bytes);
                     loadedPage.SetData(encodedImage);
-                        
+
                     loadedPage.height = info.PagesInfo[pageNumber - 1].Height;
                     loadedPage.width = info.PagesInfo[pageNumber - 1].Width;
                     loadedPage.number = pageNumber;
@@ -235,6 +227,21 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Controllers
                 // set exception message
                 return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex, password));
             }
+        }
+
+        private string getDocumentType(IDocumentInfo info)
+        {
+            string documentType = string.Empty;
+            if (info.FileType != null)
+            {
+                documentType = SupportedImageFormats.Contains(info.FileType.Extension) ? "image" : info.FileType.ToString();
+            }
+            else
+            {
+                documentType = "Portable Document Format";
+            }
+
+            return documentType;
         }
 
         private static List<string> GetAllPagesContent(GroupDocs.Annotation.Annotator annotator, IDocumentInfo pages)

--- a/src/Products/Annotation/Util/AnnotationMapper.cs
+++ b/src/Products/Annotation/Util/AnnotationMapper.cs
@@ -23,7 +23,7 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Util
         /// <param name="annotations">AnnotationInfo[]</param>
         /// <param name="pageNumber">int</param>
         /// <returns></returns>
-        public static AnnotationDataEntity[] MapForPage(AnnotationBase[] annotations, int pageNumber, PageInfo pageInfo)
+        public static AnnotationDataEntity[] MapForPage(AnnotationBase[] annotations, int pageNumber, PageInfo pageInfo, string documentType)
         {
             // initiate annotations data array
             IList<AnnotationDataEntity> pageAnnotations = new List<AnnotationDataEntity>();
@@ -34,7 +34,7 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Util
                 AnnotationBase annotationInfo = annotations[n];
                 if (pageNumber == annotationInfo.PageNumber + 1)
                 {
-                    AnnotationDataEntity annotation = MapAnnotationDataEntity(annotationInfo, pageInfo);
+                    AnnotationDataEntity annotation = MapAnnotationDataEntity(annotationInfo, pageInfo, documentType);
                     pageAnnotations.Add(annotation);
                 }
             }
@@ -47,7 +47,7 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Util
         /// </summary>
         /// <param name="annotationInfo">AnnotationInfo</param>
         /// <returns>AnnotationDataEntity</returns>
-        public static AnnotationDataEntity MapAnnotationDataEntity(AnnotationBase annotationInfo, PageInfo pageInfo)
+        public static AnnotationDataEntity MapAnnotationDataEntity(AnnotationBase annotationInfo, PageInfo pageInfo, string documentType)
         {
             string annotationTypeName = Enum.GetName(typeof(AnnotationType), annotationInfo.Type);
             float maxY = 0, minY = 0, maxX = 0, minX = 0;
@@ -92,7 +92,7 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Util
             string text = annotationInfo is IText ? ((IText)annotationInfo).Text : (annotationInfo is ITextToReplace ? ((ITextToReplace)annotationInfo).TextToReplace : "");
             annotation.text = text;
             // TODO: remove comment after check all annotations types on main formats
-            annotation.top = annotationInfo is IBox ? boxY : (annotationInfo is IPoints ? pageInfo.Height - maxY : 0);
+            annotation.top = annotationInfo is IBox ? boxY : (annotationInfo is IPoints ? (!documentType.Equals("image") ? pageInfo.Height - maxY : minY) : 0);
             annotation.type = char.ToLowerInvariant(annotationTypeName[0]) + annotationTypeName.Substring(1);
             annotation.width = annotationInfo is IBox ? boxWidth : (annotationInfo is IPoints ? (maxX - minX) : 0);
             //  each reply data


### PR DESCRIPTION
Fix related to the issue described in following [comment](https://github.com/groupdocs-annotation/GroupDocs.Annotation-for-.NET-MVC/issues/67#issuecomment-825877794).

Changes affected only annotations with types `TextHighlight/TextStrikeout/TextUnderline` added on images.

Issues left:
- annotations have excessive length;
- `textUnderline` annotation is adding upside down.